### PR TITLE
Compatibility with Git

### DIFF
--- a/app/models/hudson_build.rb
+++ b/app/models/hudson_build.rb
@@ -152,8 +152,13 @@ class HudsonBuild < ActiveRecord::Base
   def get_revision_no(elem)
     retval = get_element_value(elem, "revision")
     return retval if retval != ""
+    retval = get_element_value(elem, "commitId") # for Git Plugin
+    return retval if retval != ""
     retval = get_element_value(elem, "rev") # for mercurial or hudson 1.340
-    return retval
+    return retval if retval != ""
+
+    Rails.logger.warn('No revision found in element: ' + elem.to_s)
+    return ''
   end
 
 end

--- a/assets/javascripts/jquery.build_result_appender.js
+++ b/assets/javascripts/jquery.build_result_appender.js
@@ -8,7 +8,7 @@
     jQuery(document).ready(function() {
       jQuery.each(options.revisions, function(revision, results) {
         anchor = jQuery("div#issue-changesets").find("a").filter(function(){
-            return jQuery(this).text().match(options.label_revision + " " + revision);
+            return jQuery(this).attr('href').match('.*/' + revision);
           }).get(0);
         changeset_refs = jQuery(anchor).parent().next("div.wiki");
         message = jQuery("<p/>", {


### PR DESCRIPTION
This fixes using redmine_jenkins with Git Plugin in Jenkins and git repository in Redmine.
There were 2 problems:
- the plugin couldn't find the revision number of a changeset (it's under "commitId" for git)
- plugin's JavaScript couldn't find the link to revision in issues (it's shown as short revision number for git)

BTW what was the reason for forking from https://bitbucket.org/nobiinu_and/redmine_hudson?
